### PR TITLE
Update MeEndpoint.cs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ The OidcProxy is an identity-aware reverse proxy. It is a framework that's desig
 - This reduces the risk of impersonation.
 - This reduces the attack surface because, in this scenario, an attacker who does not have access to the webserver cannot be issued any tokens. 
 
+## Important upgrade notes
+:warning: **v2 -> v3**:
+ - /.auth/me endpoint responds with `401` instead of `404` 
+
 ## Getting started with OidcProxy.Net
 
 To get started, configure your identity provider. Create a Client that uses the `Authorization Code` grant with PKCE. It must provide refresh tokens too. This client will have a `client_id` and a `client_secret`. Use those to scaffold a boilerplate project:

--- a/src/OidcProxy.Net.Auth0/OidcProxy.Net.Auth0.csproj
+++ b/src/OidcProxy.Net.Auth0/OidcProxy.Net.Auth0.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         
         <PackageId>OidcProxy.Net.Auth0</PackageId>
-        <Version>2.0.6</Version>
+        <Version>3.0.0</Version>
         <Authors>Albert Starreveld</Authors>
         <Company>OidcProxy.net</Company>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -20,8 +20,8 @@
         <PackageIcon>logo.png</PackageIcon>
         <SignAssembly>true</SignAssembly>
         <LangVersion>12</LangVersion>
-        <PackageReleaseNotes>Upgrades:
-            - build(deps): bump IdentityModel.OidcClient from 5.2.1 to 6.0.0
+        <PackageReleaseNotes>Fixes:
+            - fix: /.auth/me endpoint responds with 401 instead of 404
         </PackageReleaseNotes>
     </PropertyGroup>
 

--- a/src/OidcProxy.Net.EntraId/OidcProxy.Net.EntraId.csproj
+++ b/src/OidcProxy.Net.EntraId/OidcProxy.Net.EntraId.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>OidcProxy.Net.EntraId</PackageId>
-    <Version>2.0.6</Version>
+    <Version>3.0.0</Version>
     <Authors>Albert Starreveld</Authors>
     <Company>OidcProxy.net</Company>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -20,8 +20,8 @@
     <PackageIcon>logo.png</PackageIcon>        
     <SignAssembly>true</SignAssembly>        
     <LangVersion>12</LangVersion>
-    <PackageReleaseNotes>Upgrades:
-      - build(deps): bump IdentityModel.OidcClient from 5.2.1 to 6.0.0
+    <PackageReleaseNotes>Fixes:
+      - fix: /.auth/me endpoint responds with 401 instead of 404
     </PackageReleaseNotes>
   </PropertyGroup>
   

--- a/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
+++ b/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>OidcProxy.Net.OpenIdConnect</PackageId>
-        <Version>2.0.6</Version>
+        <Version>3.0.0</Version>
         <Authors>Albert Starreveld</Authors>
         <Company>OidcProxy.net</Company>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -20,8 +20,8 @@
         <PackageIcon>logo.png</PackageIcon>
         <SignAssembly>true</SignAssembly>
         <LangVersion>12</LangVersion>
-        <PackageReleaseNotes>Upgrades:
-            - build(deps): bump IdentityModel.OidcClient from 5.2.1 to 6.0.0
+        <PackageReleaseNotes>Fixes:
+            - fix: /.auth/me endpoint responds with 401 instead of 404
         </PackageReleaseNotes>
     </PropertyGroup>
 

--- a/src/OidcProxy.Net/Endpoints/MeEndpoint.cs
+++ b/src/OidcProxy.Net/Endpoints/MeEndpoint.cs
@@ -13,7 +13,7 @@ internal static class MeEndpoint
     {
         if (!authSession.HasIdToken())
         {
-            return Results.NotFound();
+            return Results.Unauthorized();
         }
 
         context.Response.Headers.CacheControl = $"no-cache, no-store, must-revalidate";

--- a/src/OidcProxy.Net/OidcProxy.Net.csproj
+++ b/src/OidcProxy.Net/OidcProxy.Net.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>OidcProxy.Net</PackageId>
-        <Version>2.0.6</Version>
+        <Version>3.0.0</Version>
         <Authors>Albert Starreveld</Authors>
         <Company>OidcProxy.net</Company>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -19,8 +19,8 @@
         <PackageIcon>logo.png</PackageIcon>
         <SignAssembly>true</SignAssembly>
         <LangVersion>12</LangVersion>
-        <PackageReleaseNotes>Upgrades:
-            - build(deps): bump IdentityModel.OidcClient from 5.2.1 to 6.0.0
+        <PackageReleaseNotes>Fixes:
+            - fix: /.auth/me endpoint responds with 401 instead of 404
         </PackageReleaseNotes>
     </PropertyGroup>
 


### PR DESCRIPTION
Semantically it make more sense the response to be 401 (unauthorized) instead of 404 (not found).