### PR TITLE
Allow additional YARP middleware to be specified

### DIFF
--- a/src/OidcProxy.Net.Auth0/ModuleInitializer.cs
+++ b/src/OidcProxy.Net.Auth0/ModuleInitializer.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Builder;
-using OidcProxy.Net.ModuleInitializers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using OidcProxy.Net.ModuleInitializers;
 
 namespace OidcProxy.Net.Auth0;
 
@@ -9,17 +9,17 @@ public static class ModuleInitializer
 {
     public static void ConfigureAuth0(this ProxyOptions options, IConfigurationSection configurationSection, string endpointName = ".auth")
         => ConfigureAuth0(options, configurationSection.Get<Auth0Config>(), endpointName);
-    
+
     public static void ConfigureAuth0(this ProxyOptions options, Auth0Config config, string endpointName = ".auth")
     {
         if (!config.Validate(out var errors))
         {
             throw new NotSupportedException(string.Join(", ", errors));
         }
-        
+
         options.RegisterIdentityProvider<Auth0IdentityProvider, Auth0Config>(config, endpointName);
     }
-    
+
     /// <summary>
     /// Initialises the BFF. Also use app.UseAuth0Proxy();
     /// </summary>
@@ -39,21 +39,21 @@ public static class ModuleInitializer
         var endpointName = config.EndpointName ?? ".auth";
         var routes = config.ReverseProxy?.Routes.ToRouteConfig();
         var clusters = config.ReverseProxy?.Clusters.ToClusterConfig();
-        
+
         if (auth0Config == null)
         {
             throw new ArgumentException("Failed to initialise OidcProxy.Net. " +
                 $"Invoke `builder.Services.AddOidcProxy(..)` with an instance of `{nameof(Auth0ProxyConfig)}` " +
                 $"and provide a value for {nameof(Auth0ProxyConfig)}.{nameof(config.Auth0)}.");
         }
-        
+
         if (routes == null || !routes.Any())
         {
             throw new ArgumentException("Failed to initialise OidcProxy.Net. " +
                 $"Invoke `builder.Services.AddOidcProxy(..)` with an instance of `{nameof(Auth0ProxyConfig)}` " +
                 $"and provide a value for {nameof(Auth0ProxyConfig)}.{nameof(config.ReverseProxy)}.{nameof(config.ReverseProxy.Routes)}.");
         }
-        
+
         if (clusters == null || !clusters.Any())
         {
             throw new ArgumentException("Failed to initialise OidcProxy.Net. " +
@@ -69,26 +69,26 @@ public static class ModuleInitializer
             AssignIfNotNull(config.CookieName, cookieName => options.CookieName = cookieName);
             AssignIfNotNull(config.NameClaim, nameClaim => options.NameClaim = nameClaim);
             AssignIfNotNull(config.RoleClaim, roleClaim => options.RoleClaim = roleClaim);
-            
+
             options.EnableUserPreferredLandingPages = config.EnableUserPreferredLandingPages;
             options.AlwaysRedirectToHttps = !config.AlwaysRedirectToHttps.HasValue || config.AlwaysRedirectToHttps.Value;
             options.SetAllowedLandingPages(config.AllowedLandingPages);
-            
+
             if (config.SessionIdleTimeout.HasValue)
             {
                 options.SessionIdleTimeout = config.SessionIdleTimeout.Value;
             }
-            
-            options.ConfigureAuth0(auth0Config, endpointName);
-        
-            options.ConfigureYarp(yarp => yarp.LoadFromMemory(routes, clusters));
-            
+
             configureOptions?.Invoke(options);
+
+            options.ConfigureAuth0(auth0Config, endpointName);
+
+            options.ConfigureYarp(yarp => yarp.LoadFromMemory(routes, clusters));
         });
     }
 
     public static void UseAuth0Proxy(this WebApplication app) => app.UseOidcProxy();
-        
+
     private static void AssignIfNotNull<T>(T? value, Action<T> @do)
     {
         if (value != null)

--- a/src/OidcProxy.Net.EntraId/ModuleInitializer.cs
+++ b/src/OidcProxy.Net.EntraId/ModuleInitializer.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
-using OidcProxy.Net.ModuleInitializers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using OidcProxy.Net.ModuleInitializers;
 
 namespace OidcProxy.Net.EntraId;
 
@@ -16,10 +16,10 @@ public static class ModuleInitializer
         {
             throw new NotSupportedException(string.Join(", ", errors));
         }
-        
+
         options.RegisterIdentityProvider<EntraIdIdentityProvider, EntraIdConfig>(config, endpointName);
     }
-    
+
     /// <summary>
     /// Initialises the BFF. Also use app.UseOidcProxy();
     /// </summary>
@@ -39,21 +39,21 @@ public static class ModuleInitializer
         var endpointName = config.EndpointName ?? ".auth";
         var routes = config.ReverseProxy?.Routes.ToRouteConfig();
         var clusters = config.ReverseProxy?.Clusters.ToClusterConfig();
-        
+
         if (entraIdConfig == null)
         {
             throw new ArgumentException("Failed to initialise OidcProxy.Net. " +
                 $"Invoke `builder.Services.AddOidcProxy(..)` with an instance of `{nameof(EntraIdProxyConfig)}` " +
                 $"and provide a value for {nameof(EntraIdProxyConfig)}.{nameof(config.EntraId)}.");
         }
-        
+
         if (routes == null || !routes.Any())
         {
             throw new ArgumentException("Failed to initialise OidcProxy.Net. " +
                 $"Invoke `builder.Services.AddOidcProxy(..)` with an instance of `{nameof(EntraIdProxyConfig)}` " +
                 $"and provide a value for {nameof(EntraIdProxyConfig)}.{nameof(config.ReverseProxy)}.{nameof(config.ReverseProxy.Routes)}.");
         }
-        
+
         if (clusters == null || !clusters.Any())
         {
             throw new ArgumentException("Failed to initialise OidcProxy.Net. " +
@@ -69,26 +69,26 @@ public static class ModuleInitializer
             AssignIfNotNull(config.CookieName, cookieName => options.CookieName = cookieName);
             AssignIfNotNull(config.NameClaim, nameClaim => options.NameClaim = nameClaim);
             AssignIfNotNull(config.RoleClaim, roleClaim => options.RoleClaim = roleClaim);
-            
+
             options.EnableUserPreferredLandingPages = config.EnableUserPreferredLandingPages;
             options.AlwaysRedirectToHttps = !config.AlwaysRedirectToHttps.HasValue || config.AlwaysRedirectToHttps.Value;
             options.SetAllowedLandingPages(config.AllowedLandingPages);
-            
+
             if (config.SessionIdleTimeout.HasValue)
             {
                 options.SessionIdleTimeout = config.SessionIdleTimeout.Value;
             }
-            
-            ConfigureEntraId(options, entraIdConfig, endpointName);
-        
-            options.ConfigureYarp(yarp => yarp.LoadFromMemory(routes, clusters));
-            
+
             configureOptions?.Invoke(options);
+
+            ConfigureEntraId(options, entraIdConfig, endpointName);
+
+            options.ConfigureYarp(yarp => yarp.LoadFromMemory(routes, clusters));
         });
     }
 
     public static void UseEntraIdProxy(this WebApplication app) => app.UseOidcProxy();
-        
+
     private static void AssignIfNotNull<T>(T? value, Action<T> @do)
     {
         if (value != null)

--- a/src/OidcProxy.Net.OpenIdConnect/ModuleInitializer.cs
+++ b/src/OidcProxy.Net.OpenIdConnect/ModuleInitializer.cs
@@ -1,7 +1,6 @@
-using Microsoft.AspNetCore.Builder;
-using OidcProxy.Net.ModuleInitializers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using OidcProxy.Net.ModuleInitializers;
 
 namespace OidcProxy.Net.OpenIdConnect;
 
@@ -32,27 +31,27 @@ public static class ModuleInitializer
         {
             throw new ArgumentNullException(nameof(config), "Failed to initialise OidcProxy.Net. Config cannot be null. " +
                 $"Invoke `builder.Services.AddOidcProxy(..)` with an instance of `{nameof(OidcProxyConfig)}`.");
-        } 
+        }
 
         var oidcConfig = config.Oidc;
         var endpointName = config.EndpointName ?? ".auth";
         var routes = config.ReverseProxy?.Routes.ToRouteConfig();
         var clusters = config.ReverseProxy?.Clusters.ToClusterConfig();
-        
+
         if (oidcConfig == null)
         {
             throw new ArgumentException("Failed to initialise OidcProxy.Net. " +
                 $"Invoke `builder.Services.AddOidcProxy(..)` with an instance of `{nameof(OidcProxyConfig)}` " +
                 $"and provide a value for {nameof(OidcProxyConfig)}.{nameof(config.Oidc)}.");
         }
-        
+
         if (routes == null || !routes.Any())
         {
             throw new ArgumentException("Failed to initialise OidcProxy.Net. " +
                 $"Invoke `builder.Services.AddOidcProxy(..)` with an instance of `{nameof(OidcProxyConfig)}` " +
                 $"and provide a value for {nameof(OidcProxyConfig)}.{nameof(config.ReverseProxy)}.{nameof(config.ReverseProxy.Routes)}.");
         }
-        
+
         if (clusters == null || !clusters.Any())
         {
             throw new ArgumentException("Failed to initialise OidcProxy.Net. " +
@@ -68,21 +67,21 @@ public static class ModuleInitializer
             AssignIfNotNull(config.CookieName, cookieName => options.CookieName = cookieName);
             AssignIfNotNull(config.NameClaim, nameClaim => options.NameClaim = nameClaim);
             AssignIfNotNull(config.RoleClaim, roleClaim => options.RoleClaim = roleClaim);
-            
-            options.EnableUserPreferredLandingPages = config.EnableUserPreferredLandingPages;            
+
+            options.EnableUserPreferredLandingPages = config.EnableUserPreferredLandingPages;
             options.AlwaysRedirectToHttps = !config.AlwaysRedirectToHttps.HasValue || config.AlwaysRedirectToHttps.Value;
             options.SetAllowedLandingPages(config.AllowedLandingPages);
-            
+
             if (config.SessionIdleTimeout.HasValue)
             {
                 options.SessionIdleTimeout = config.SessionIdleTimeout.Value;
             }
-            
-            options.ConfigureOpenIdConnect(oidcConfig, endpointName);
-        
-            options.ConfigureYarp(yarp => yarp.LoadFromMemory(routes, clusters));
-            
+
             configureOptions?.Invoke(options);
+
+            options.ConfigureOpenIdConnect(oidcConfig, endpointName);
+
+            options.ConfigureYarp(yarp => yarp.LoadFromMemory(routes, clusters));
         });
     }
 

--- a/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
+++ b/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
@@ -28,8 +28,6 @@
     <ItemGroup>
         <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
         <PackageReference Include="jose-jwt" Version="5.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OidcProxy.Net/Middleware/IYarpMiddleware.cs
+++ b/src/OidcProxy.Net/Middleware/IYarpMiddleware.cs
@@ -2,7 +2,15 @@ using Microsoft.AspNetCore.Http;
 
 namespace OidcProxy.Net.Middleware;
 
+/// <summary>
+/// This interface must be implemented by custom middleware that is added into the YARP pipeline
+/// by <see cref="ModuleInitializers.ProxyOptions.AddYarpMiddleware"/>.
+/// </summary>
 public interface IYarpMiddleware
 {
+    /// <summary>
+    /// Implementations of this method should perform their custom processing using the provided context
+    /// and then await next(context) to continue pipeline processing.
+    /// </summary>
     Task Apply(HttpContext context, Func<HttpContext, Task> next);
 }

--- a/src/OidcProxy.Net/Middleware/IYarpMiddleware.cs
+++ b/src/OidcProxy.Net/Middleware/IYarpMiddleware.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace OidcProxy.Net.Middleware;
 
-internal interface IYarpMiddleware
+public interface IYarpMiddleware
 {
     Task Apply(HttpContext context, Func<HttpContext, Task> next);
 }

--- a/src/OidcProxy.Net/ModuleInitializers/IdpRegistrations.cs
+++ b/src/OidcProxy.Net/ModuleInitializers/IdpRegistrations.cs
@@ -1,8 +1,6 @@
-using OidcProxy.Net.Endpoints;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+using OidcProxy.Net.Endpoints;
 using OidcProxy.Net.IdentityProviders;
 using OidcProxy.Net.Middleware;
 
@@ -16,8 +14,8 @@ internal class IdpRegistration<TIdentityProvider, TOptions> : IIdpRegistration w
     private readonly Action<WebApplication> _idpEndpointRegistration;
 
     private readonly Action<IReverseProxyBuilder> _proxyConfiguration;
-    
-    private readonly List<Type> _yarpMiddlewareRegistrations = new();
+
+    private readonly List<Type> _yarpMiddlewareRegistrations = [typeof(TokenRenewalMiddleware)];
 
     public IdpRegistration(TOptions options, string endpointName = ".auth")
     {
@@ -36,10 +34,13 @@ internal class IdpRegistration<TIdentityProvider, TOptions> : IIdpRegistration w
         };
 
         _idpEndpointRegistration = app => app.MapAuthenticationEndpoints(endpointName);
-        
-        _yarpMiddlewareRegistrations.Add(typeof(TokenRenewalMiddleware));
     }
-    
+
+    public void AddYarpMiddleware(Type handlerType)
+    {
+        _yarpMiddlewareRegistrations.Add(handlerType);
+    }
+
     public void Apply(IServiceCollection serviceCollection)
     {
         _idpRegistration.Invoke(serviceCollection);

--- a/src/OidcProxy.Net/ModuleInitializers/ProxyOptions.cs
+++ b/src/OidcProxy.Net/ModuleInitializers/ProxyOptions.cs
@@ -184,9 +184,9 @@ public class ProxyOptions
         IdpRegistration = registration;
     }
 
-    public void AddYarpMiddleware(Type handlerType)
+    public void AddYarpMiddleware<THandler>() where THandler : IYarpMiddleware
     {
-        _customYarpMiddleware.Add(handlerType);
+        _customYarpMiddleware.Add(typeof(THandler));
     }
 
     /// <summary>

--- a/src/OidcProxy.Net/ModuleInitializers/ProxyOptions.cs
+++ b/src/OidcProxy.Net/ModuleInitializers/ProxyOptions.cs
@@ -184,6 +184,10 @@ public class ProxyOptions
         IdpRegistration = registration;
     }
 
+    /// <summary>
+    /// Adds middleware into the YARP processing pipeline.
+    /// </summary>
+    /// <typeparam name="THandler">The type implementing the middleware.</typeparam>
     public void AddYarpMiddleware<THandler>() where THandler : IYarpMiddleware
     {
         _customYarpMiddleware.Add(typeof(THandler));

--- a/src/OidcProxy.Net/ModuleInitializers/ProxyOptions.cs
+++ b/src/OidcProxy.Net/ModuleInitializers/ProxyOptions.cs
@@ -1,8 +1,5 @@
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OidcProxy.Net.IdentityProviders;
 using OidcProxy.Net.Locking;
 using OidcProxy.Net.Locking.Distributed.Redis;
@@ -10,10 +7,10 @@ using OidcProxy.Net.Locking.InMemory;
 using OidcProxy.Net.Logging;
 using OidcProxy.Net.Middleware;
 using OidcProxy.Net.OpenIdConnect;
-using StackExchange.Redis;
 using RedLockNet;
 using RedLockNet.SERedis;
 using RedLockNet.SERedis.Configuration;
+using StackExchange.Redis;
 
 namespace OidcProxy.Net.ModuleInitializers;
 
@@ -24,17 +21,19 @@ public class ProxyOptions
     private Action<IReverseProxyBuilder> _applyReverseProxyConfiguration = _ => { };
 
     private Action<IServiceCollection> _applyClaimsTransformationRegistration = (s) => s.AddTransient<IClaimsTransformation, DefaultClaimsTransformation>();
-    
+
     private Action<IServiceCollection> _applyBackBone = (s) => s.AddTransient<IConcurrentContext, InMemoryConcurrentContext>();
 
     private Action<IServiceCollection> _applyAuthenticationCallbackHandlerRegistration = (s) => s.AddTransient<IAuthenticationCallbackHandler, DefaultAuthenticationCallbackHandler>();
-    
+
     private Action<IServiceCollection> _applyJwtParser = (s) => s.AddTransient<ITokenParser, JwtParser>();
+
+    private List<Type> _customYarpMiddleware = [];
 
     internal Uri? CustomHostName = null;
 
     internal LandingPage ErrorPage;
-        
+
     internal LandingPage LandingPage;
 
     internal LandingPage[] AllowedUserPreferredLandingPages = Array.Empty<LandingPage>();
@@ -48,13 +47,13 @@ public class ProxyOptions
     /// Get or set a value that indicates the amount of time of inactivity after which the session will be abandoned.
     /// </summary>
     public TimeSpan SessionIdleTimeout { get; set; } = TimeSpan.FromMinutes(20);
-    
+
     /// <summary>
     /// Gets ors sets a value which indicates whether or not the redirect_uri will automatically be rewritten to http
     /// instead of https. This feature might come in handy when hosting the software in a Docker image.
     /// </summary>
     public bool AlwaysRedirectToHttps { get; set; } = true;
-    
+
     /// <summary>
     /// Gets or sets a value that indicates whether or not the user is allowed to specify the page he/she wants to be
     /// redirected to after authenticating successfully.
@@ -65,7 +64,7 @@ public class ProxyOptions
     /// The name of the claim that represents the username.
     /// </summary>
     public string NameClaim { get; set; } = "sub";
-    
+
     /// <summary>
     /// The name of the claim that represents the username.
     /// </summary>
@@ -82,12 +81,12 @@ public class ProxyOptions
                                     "Cannot initialize OidcProxy.Net. " +
                                     "Invalid error page. " +
                                     "The path to the error page must be relative and may not have a querystring.";
-        
+
         if (!LandingPage.TryParse(errorPage, out var value))
         {
             throw new NotSupportedException(errorMessage);
         }
-        
+
         if (errorPage.Contains('?') || errorPage.Contains('#'))
         {
             throw new NotSupportedException(errorMessage);
@@ -108,13 +107,13 @@ public class ProxyOptions
                                         "Cannot initialize OidcProxy.Net. " +
                                         "Invalid landing page. " +
                                         "The path to the landing page must be relative.";
-            
+
             throw new NotSupportedException(errorMessage);
         }
-        
+
         LandingPage = value;
     }
-    
+
     /// <summary>
     /// 
     /// </summary>
@@ -127,7 +126,7 @@ public class ProxyOptions
         }
 
         var allowedLandingPages = new List<LandingPage>();
-        
+
         foreach (var landingPage in landingPages)
         {
             if (!LandingPage.TryParse(landingPage, out var value))
@@ -136,13 +135,13 @@ public class ProxyOptions
                                             "Cannot initialize OidcProxy.Net. " +
                                             "Invalid landing page. " +
                                             "The path to the landing page must be relative.";
-            
+
                 throw new NotSupportedException(errorMessage);
             }
-            
+
             allowedLandingPages.Add(value);
         }
-        
+
         AllowedUserPreferredLandingPages = allowedLandingPages.ToArray();
     }
 
@@ -165,8 +164,8 @@ public class ProxyOptions
         CustomHostName = hostname;
     }
 
-    public void RegisterIdentityProvider<TIdentityProvider, TOptions>(TOptions options, string endpointName = ".auth") 
-        where TIdentityProvider : class, IIdentityProvider 
+    public void RegisterIdentityProvider<TIdentityProvider, TOptions>(TOptions options, string endpointName = ".auth")
+        where TIdentityProvider : class, IIdentityProvider
         where TOptions : class
     {
         if (IdpRegistration != null)
@@ -175,7 +174,19 @@ public class ProxyOptions
                                             "Configuring multiple IdentityProviders is not supported.");
         }
 
-        IdpRegistration = new IdpRegistration<TIdentityProvider, TOptions>(options, endpointName);
+        var registration = new IdpRegistration<TIdentityProvider, TOptions>(options, endpointName);
+
+        foreach (var handlerType in _customYarpMiddleware)
+        {
+            registration.AddYarpMiddleware(handlerType);
+        }
+
+        IdpRegistration = registration;
+    }
+
+    public void AddYarpMiddleware(Type handlerType)
+    {
+        _customYarpMiddleware.Add(handlerType);
     }
 
     /// <summary>
@@ -195,7 +206,7 @@ public class ProxyOptions
     {
         _applyJwtParser = s => s.AddTransient<ITokenParser, TTokenParser>();
     }
-    
+
     /// <summary>
     /// Configure how to decrypt a JWE
     /// </summary>
@@ -269,7 +280,7 @@ public class ProxyOptions
         _applyBackBone(serviceCollection);
 
         IdpRegistration.Apply(proxyBuilder);
-        
+
         IdpRegistration.Apply(serviceCollection);
 
         _applyClaimsTransformationRegistration(serviceCollection);
@@ -283,20 +294,20 @@ public class ProxyOptions
             {
                 options.IdleTimeout = SessionIdleTimeout;
                 options.Cookie.HttpOnly = true;
-                options.Cookie.IsEssential = true;    
+                options.Cookie.IsEssential = true;
                 options.Cookie.Name = CookieName;
             });
-        
+
         serviceCollection
             .AddTransient(_ => this)
             .AddTransient<IRedirectUriFactory, RedirectUriFactory>();
-        
+
         serviceCollection
             .AddHttpContextAccessor()
             .AddTransient<TokenFactory>()
             .AddTransient<AuthSession>()
             .AddTransient<ILogger, DefaultLogger>();
-                
+
         serviceCollection
             .AddAuthentication(OidcProxyAuthenticationHandler.SchemaName)
             .AddScheme<OidcProxyAuthenticationSchemeOptions, OidcProxyAuthenticationHandler>(OidcProxyAuthenticationHandler.SchemaName, null);


### PR DESCRIPTION
Resolves #186 

There us already a list for multiple YARP middleware handler types, i.e. `_yarpMiddlewareRegistrations` in `OidcProxy.Net.ModuleInitializers.IdpRegistration`, but no way to add extra types; only the built-in `TokenRenewalMiddleware` is added.

The approach taken in this PR is to add an `AddYarpMiddleware` method to `ProxyOptions`, collect the added types in a local list, and forward these types to `IdpRegistration` when `ProxyOptions.RegisterIdentityProvider` is called.

For this to work, the options callback needs to be called _before_ configuring YARP, in each of the adapters for OpenIdConnect, EntraId and Auth0.

The added YARO middleware needs to implement the `IYarpMiddleware` interface so this has been changed from `internal` to `public` to make it available.