### PR TITLE
fix(RS256 certificate rotation): Re-obtain the JSON Web KeySet on key validation error

### DIFF
--- a/src/OidcProxy.Net.Auth0/OidcProxy.Net.Auth0.csproj
+++ b/src/OidcProxy.Net.Auth0/OidcProxy.Net.Auth0.csproj
@@ -21,11 +21,11 @@
         <SignAssembly>true</SignAssembly>
         <LangVersion>12</LangVersion>
         <PackageReleaseNotes>
-            v5.0:
+            v4.0 -> v5.0:
             Fixes
-            - Fix for RS256 key-rotation
+            - Invalidate JSON Web Key Set cache when (RS256) keys are rotated
 
-            v4.0:
+            v3.0 -> v5.0:
             Enhancements
             - Implemented signature verification RS256
             - Implemented signature verification HS256

--- a/src/OidcProxy.Net.Auth0/OidcProxy.Net.Auth0.csproj
+++ b/src/OidcProxy.Net.Auth0/OidcProxy.Net.Auth0.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         
         <PackageId>OidcProxy.Net.Auth0</PackageId>
-        <Version>4.0.0</Version>
+        <Version>5.0.0</Version>
         <Authors>Albert Starreveld</Authors>
         <Company>OidcProxy.net</Company>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -20,7 +20,13 @@
         <PackageIcon>logo.png</PackageIcon>
         <SignAssembly>true</SignAssembly>
         <LangVersion>12</LangVersion>
-        <PackageReleaseNotes>Enhancements
+        <PackageReleaseNotes>
+            v5.0:
+            Fixes
+            - Fix for RS256 key-rotation
+
+            v4.0:
+            Enhancements
             - Implemented signature verification RS256
             - Implemented signature verification HS256
 

--- a/src/OidcProxy.Net.EntraId/OidcProxy.Net.EntraId.csproj
+++ b/src/OidcProxy.Net.EntraId/OidcProxy.Net.EntraId.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>OidcProxy.Net.EntraId</PackageId>
-    <Version>4.0.0</Version>
+    <Version>5.0.0</Version>
     <Authors>Albert Starreveld</Authors>
     <Company>OidcProxy.net</Company>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -20,7 +20,13 @@
     <PackageIcon>logo.png</PackageIcon>        
     <SignAssembly>true</SignAssembly>        
     <LangVersion>12</LangVersion>
-    <PackageReleaseNotes>Enhancements
+    <PackageReleaseNotes>
+      v5.0:
+      Fixes
+      - Fix for RS256 key-rotation
+
+      v4.0:
+      Enhancements
       - Implemented signature verification RS256
       - Implemented signature verification HS256
 

--- a/src/OidcProxy.Net.EntraId/OidcProxy.Net.EntraId.csproj
+++ b/src/OidcProxy.Net.EntraId/OidcProxy.Net.EntraId.csproj
@@ -21,11 +21,11 @@
     <SignAssembly>true</SignAssembly>        
     <LangVersion>12</LangVersion>
     <PackageReleaseNotes>
-      v5.0:
+      v4.0 -> v5.0:
       Fixes
-      - Fix for RS256 key-rotation
+      - Invalidate JSON Web Key Set cache when (RS256) keys are rotated
 
-      v4.0:
+      v3.0 -> v5.0:
       Enhancements
       - Implemented signature verification RS256
       - Implemented signature verification HS256

--- a/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
+++ b/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
@@ -21,11 +21,11 @@
         <SignAssembly>true</SignAssembly>
         <LangVersion>12</LangVersion>
         <PackageReleaseNotes>
-            v5.0:
+            v4.0 -> v5.0:
             Fixes
-            - Fix for RS256 key-rotation. 
-            
-            v4.0:
+            - Invalidate JSON Web Key Set cache when (RS256) keys are rotated
+
+            v3.0 -> v5.0:
             Enhancements
             - Implemented signature verification RS256
             - Implemented signature verification HS256

--- a/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
+++ b/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>OidcProxy.Net.OpenIdConnect</PackageId>
-        <Version>4.0.0</Version>
+        <Version>5.0.0</Version>
         <Authors>Albert Starreveld</Authors>
         <Company>OidcProxy.net</Company>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -20,7 +20,13 @@
         <PackageIcon>logo.png</PackageIcon>
         <SignAssembly>true</SignAssembly>
         <LangVersion>12</LangVersion>
-        <PackageReleaseNotes>Enhancements
+        <PackageReleaseNotes>
+            v5.0:
+            Fixes
+            - Fix for RS256 key-rotation. 
+            
+            v4.0:
+            Enhancements
             - Implemented signature verification RS256
             - Implemented signature verification HS256
 

--- a/src/OidcProxy.Net.OpenIdConnect/OpenIdConnectIdentityProvider.cs
+++ b/src/OidcProxy.Net.OpenIdConnect/OpenIdConnectIdentityProvider.cs
@@ -84,13 +84,13 @@ public class OpenIdConnectIdentityProvider(
         
         return new TokenResponse(response.AccessToken, response.IdentityToken, response.RefreshToken, expiryDate);
     }
-    
-    public async Task<IEnumerable<KeySet>> GetJwksAsync()
+
+    public async Task<IEnumerable<KeySet>> GetJwksAsync(bool invalidateCache = false)
     {
         var openIdConfiguration = await GetDiscoveryDocument();
         var jwksUri = openIdConfiguration.jwks_uri;
 
-        if (cache.TryGetValue(jwksUri, out var keySet) && keySet != null)
+        if (!invalidateCache && cache.TryGetValue(jwksUri, out var keySet) && keySet != null)
         {
             return (JsonWebKeySet)keySet;
         }

--- a/src/OidcProxy.Net/IdentityProviders/IIdentityProvider.cs
+++ b/src/OidcProxy.Net/IdentityProviders/IIdentityProvider.cs
@@ -27,7 +27,7 @@ public interface IIdentityProvider
     /// Gets the JSON Web Key Set
     /// </summary>
     /// <returns>The JSON Web Key Set</returns>
-    Task<IEnumerable<KeySet>> GetJwksAsync();
+    Task<IEnumerable<KeySet>> GetJwksAsync(bool invalidateCache = false);
     
     /// <summary>
     /// Exchanges the refresh_token for a new access_token as defined in section 12.1. of the OpenId Connect spec: https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken.

--- a/src/OidcProxy.Net/Jwt/SignatureValidation/JwtSignatureValidator.cs
+++ b/src/OidcProxy.Net/Jwt/SignatureValidation/JwtSignatureValidator.cs
@@ -28,6 +28,14 @@ internal class JwtSignatureValidator(IIdentityProvider identityProvider,
         }
 
         var keys = await identityProvider.GetJwksAsync();
+        if (await signatureValidator.Validate(token, keys))
+        {
+            return true;
+        }
+        
+        // If the signature verification fails, it is very well possible the keys have rotated
+        // in that case it is common practice to re-obtain the key-set and verify again.
+        keys = await identityProvider.GetJwksAsync(true);
         return await signatureValidator.Validate(token, keys);
     }
 

--- a/src/OidcProxy.Net/Jwt/SignatureValidation/KeySetNotFoundException.cs
+++ b/src/OidcProxy.Net/Jwt/SignatureValidation/KeySetNotFoundException.cs
@@ -1,0 +1,9 @@
+namespace OidcProxy.Net.Jwt.SignatureValidation;
+
+public class KeySetNotFoundException : ApplicationException
+{
+    public KeySetNotFoundException(string message) : base(message)
+    {
+        
+    }
+}

--- a/src/OidcProxy.Net/Jwt/SignatureValidation/SignatureValidator.cs
+++ b/src/OidcProxy.Net/Jwt/SignatureValidation/SignatureValidator.cs
@@ -17,8 +17,8 @@ internal abstract class SignatureValidator
         var keySet = GetKeySet(keys, header);
         if (keySet == null)
         {
-            throw new ApplicationException("Failed to validate signature. " +
-                                           "Unable to find appropriate key to validate the signature with.");
+            throw new KeySetNotFoundException("Failed to validate signature. " +
+                                              "Unable to find appropriate key to validate the signature with.");
         }
 
         // The signature is validated using JoseJWT. It uses an object to do so.

--- a/src/OidcProxy.Net/OidcProxy.Net.csproj
+++ b/src/OidcProxy.Net/OidcProxy.Net.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>OidcProxy.Net</PackageId>
-        <Version>4.0.0</Version>
+        <Version>5.0.0</Version>
         <Authors>Albert Starreveld</Authors>
         <Company>OidcProxy.net</Company>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -19,7 +19,13 @@
         <PackageIcon>logo.png</PackageIcon>
         <SignAssembly>true</SignAssembly>
         <LangVersion>12</LangVersion>
-        <PackageReleaseNotes>Enhancements
+        <PackageReleaseNotes>
+            v5.0:
+            Fixes
+            - Fix for RS256 key-rotation
+
+            v4.0:
+            Enhancements
             - Implemented signature verification RS256
             - Implemented signature verification HS256
             

--- a/src/OidcProxy.Net/OidcProxy.Net.csproj
+++ b/src/OidcProxy.Net/OidcProxy.Net.csproj
@@ -20,11 +20,11 @@
         <SignAssembly>true</SignAssembly>
         <LangVersion>12</LangVersion>
         <PackageReleaseNotes>
-            v5.0:
+            v4.0 -> v5.0:
             Fixes
-            - Fix for RS256 key-rotation
+            - Invalidate JSON Web Key Set cache when (RS256) keys are rotated
 
-            v4.0:
+            v3.0 -> v5.0:
             Enhancements
             - Implemented signature verification RS256
             - Implemented signature verification HS256

--- a/unittests/OidcProxy.Net.Tests/UnitTests/OptionsTests/RegisterIdentityProviderTests.cs
+++ b/unittests/OidcProxy.Net.Tests/UnitTests/OptionsTests/RegisterIdentityProviderTests.cs
@@ -73,7 +73,7 @@ public class RegisterIdentityProviderTests
             throw new NotImplementedException();
         }
 
-        public Task<IEnumerable<KeySet>> GetJwksAsync()
+        public Task<IEnumerable<KeySet>> GetJwksAsync(bool invalidateCache)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Re-obtain the JSON Web Key Set when the signature verification fails due to not being able to find the appropriate JSON web-key.