### PR TITLE
[Auth0] Add support for both logout endpoints (Issue #173)

### DIFF
--- a/src/OidcProxy.Net.Auth0/Auth0Config.cs
+++ b/src/OidcProxy.Net.Auth0/Auth0Config.cs
@@ -14,6 +14,8 @@ public class Auth0Config
 
     public string[] Scopes { get; set; } = Array.Empty<string>();
 
+    public bool UseOidcLogoutEndpoint { get; set; } = false;
+
     public bool FederatedLogout { get; set; } = false;
 
     public bool Validate(out IEnumerable<string> errors)

--- a/src/OidcProxy.Net.Auth0/Auth0IdentityProvider.cs
+++ b/src/OidcProxy.Net.Auth0/Auth0IdentityProvider.cs
@@ -37,13 +37,16 @@ public class Auth0IdentityProvider(
     {
         var queryStringSeparator = "?";
 
+        var redirectEndpoint = config.UseOidcLogoutEndpoint ? "/oidc/logout" : "/v2/logout";
+        var redirectQueryParameter = config.UseOidcLogoutEndpoint ? "post_logout_redirect_uri" : "returnTo";
+        
         // Docs on redirect URL
         // https://auth0.com/docs/authenticate/login/logout/redirect-users-after-logout
         var redirectUrl = string.Empty;
         if (!string.IsNullOrEmpty(redirectUri))
         {
             var returnToQueryStringValue = HttpUtility.UrlEncode(redirectUri);
-            redirectUrl = $"{queryStringSeparator}returnTo={returnToQueryStringValue}";
+            redirectUrl = $"{queryStringSeparator}{redirectQueryParameter}={returnToQueryStringValue}";
 
             queryStringSeparator = "&";
         }
@@ -51,10 +54,10 @@ public class Auth0IdentityProvider(
         // Docs on federated logout:
         // https://auth0.com/docs/authenticate/login/logout/log-users-out-of-idps
         var federated = config.FederatedLogout ? $"{queryStringSeparator}federated" : string.Empty;
-        
+
         // Auth0 does not define their end_session_endpoint in the well-known/openid-configuration
         var query = $"{redirectUrl}{federated}";
-        var endSessionUrl = $"https://{config.Domain}/oidc/logout{query}";
+        var endSessionUrl = $"https://{config.Domain}{redirectEndpoint}{query}";
         var endSessionUri = new Uri(endSessionUrl);
         
         return Task.FromResult(endSessionUri);

--- a/src/OidcProxy.Net.Auth0/Auth0IdentityProvider.cs
+++ b/src/OidcProxy.Net.Auth0/Auth0IdentityProvider.cs
@@ -40,9 +40,16 @@ public class Auth0IdentityProvider(
         var redirectEndpoint = config.UseOidcLogoutEndpoint ? "/oidc/logout" : "/v2/logout";
         var redirectQueryParameter = config.UseOidcLogoutEndpoint ? "post_logout_redirect_uri" : "returnTo";
         
+        var redirectUrl = string.Empty;
+        if (config.UseOidcLogoutEndpoint && !string.IsNullOrWhiteSpace(idToken))
+        {
+            redirectUrl = $"{queryStringSeparator}id_token_hint={HttpUtility.UrlEncode(idToken)}";
+            queryStringSeparator = "&";
+        }
+
         // Docs on redirect URL
         // https://auth0.com/docs/authenticate/login/logout/redirect-users-after-logout
-        var redirectUrl = string.Empty;
+        
         if (!string.IsNullOrEmpty(redirectUri))
         {
             var returnToQueryStringValue = HttpUtility.UrlEncode(redirectUri);


### PR DESCRIPTION
Add support for both the [alternative logout](https://auth0.com/docs/authenticate/login/logout/redirect-users-after-logout) and the [OIDC Logout](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0) endpoints in Auth0.