### PR TITLE
Pushed Authentication Option

### DIFF
--- a/src/OidcProxy.Net.Auth0/Auth0IdentityProvider.cs
+++ b/src/OidcProxy.Net.Auth0/Auth0IdentityProvider.cs
@@ -3,6 +3,7 @@ using OidcProxy.Net.IdentityProviders;
 using OidcProxy.Net.Logging;
 using OidcProxy.Net.OpenIdConnect;
 using Microsoft.Extensions.Caching.Memory;
+using IdentityModel.Client;
 
 namespace OidcProxy.Net.Auth0;
 
@@ -16,14 +17,15 @@ public class Auth0IdentityProvider(
         client,
         MapConfiguration(config))
 {
-    public override async Task<AuthorizeRequest> GetAuthorizeUrlAsync(string redirectUri)
+    protected override Parameters? GetFrontChannelParameters()
     {
-        var result = await base.GetAuthorizeUrlAsync(redirectUri);
+        var baseParams = base.GetFrontChannelParameters();
+        if (baseParams == null) {
+            baseParams = new Parameters();
+        }
 
-        var audience = HttpUtility.UrlEncode(config.Audience);
-        var authorizeRequestWithAudience = $"{result.AuthorizeUri}&audience={audience}";
-
-        return new AuthorizeRequest(new Uri(authorizeRequestWithAudience), result.CodeVerifier);
+        baseParams.Add("audience", config.Audience);
+        return baseParams;
     }
 
     public override Task RevokeAsync(string token, string traceIdentifier)

--- a/src/OidcProxy.Net.OpenIdConnect/OpenIdConnectConfig.cs
+++ b/src/OidcProxy.Net.OpenIdConnect/OpenIdConnectConfig.cs
@@ -16,6 +16,8 @@ public class OpenIdConnectConfig
 
     public string PostLogoutRedirectEndpoint { get; set; } = "/";
 
+    public bool DisablePushedAuthorization { get; set; } = false;
+
     public virtual bool Validate(out IEnumerable<string> errors)
     {
         var results = new List<string>();

--- a/unittests/OidcProxy.Net.OpenIdConnect.Tests/OpenIdConnectBffConfigurationTests.cs
+++ b/unittests/OidcProxy.Net.OpenIdConnect.Tests/OpenIdConnectBffConfigurationTests.cs
@@ -18,6 +18,7 @@ public class OpenIdConnectBffConfigurationTests
             ""offline_access""
             ],
             ""DiscoveryEndpoint"": ""https://disco.com/.well-known/openid-configuration""
+            ""DisablePushedAuthorization"": true
         },
         ""ErrorPage"": ""/error.aspx"",
         ""LandingPage"": ""/welcome.aspx"",
@@ -66,6 +67,7 @@ public class OpenIdConnectBffConfigurationTests
         _deserializedObject?.Oidc.DiscoveryEndpoint.Should().NotBeNullOrEmpty();
         _deserializedObject?.Oidc.Scopes.Should().NotBeNullOrEmpty();
         _deserializedObject?.Oidc.PostLogoutRedirectEndpoint.Should().NotBeNullOrEmpty();
+        _deserializedObject?.Oidc.DisablePushedAuthorization.Should().BeTrue();
         _deserializedObject?.EndpointName.Should().NotBeNullOrEmpty();
     }
     


### PR DESCRIPTION
The `OidcClientOptions` class contains an option to enable/disable Pushed Authentication requests.  This PR adds an option to `OpenIdConnectConfig` to enable that option to be set and passed through.  This addresses #334.

Additionally, through some reading of the OidcClient code, I was able to simplify some of the calls here.  Setting the appropriate valies on `OidcClientOptions` and using the `frontChannelParameters`, we can avoid putting query parameters in manually.