### PR TITLE
Allow running outside of the root domain

### DIFF
--- a/src/OidcProxy.Net/OpenIdConnect/RedirectUriFactory.cs
+++ b/src/OidcProxy.Net/OpenIdConnect/RedirectUriFactory.cs
@@ -12,10 +12,18 @@ internal class RedirectUriFactory(ProxyOptions options) : IRedirectUriFactory
     /// <returns>The hostname the identity provider should return the auth code to.</returns>
     public string DetermineHostName(HttpContext context)
     {
-        var hostName = options.CustomHostName == null 
-            ? new Uri($"{context.Request.Scheme}://{context.Request.Host}")
-            : new Uri($"{options.CustomHostName.Scheme}://{options.CustomHostName.Authority}");
-
+        Uri hostName;
+        if (options.CustomHostName == null)
+        {
+            hostName = new Uri($"{context.Request.Scheme}://{context.Request.Host}");
+        }
+        else
+        {
+            var host = options.CustomHostName.Authority;
+            var localPath = options.CustomHostName.LocalPath.TrimEnd('/');
+            hostName = new Uri($"{options.CustomHostName.Scheme}://{host}{localPath}");
+        }
+        
         return (hostName.Scheme == "http" && options.AlwaysRedirectToHttps)
             ? $"https://{hostName.Authority}"
             : hostName.ToString().TrimEnd('/');


### PR DESCRIPTION
The CustomHostName setting can be used to influence how the `redirect_uri` and the path to the end-session endpoint can be generated. This PR expands on this feature by including the LocalPath part of the Uri in the base address.

This is required when the BFF is running outside of the root domain, such as on `www.example.com/my-app`. 

This fixes issue #359. 