### PR TITLE
Migrate from IdentityModel to Duende IdentityModel

### DIFF
--- a/src/OidcProxy.Net.Auth0/Auth0IdentityProvider.cs
+++ b/src/OidcProxy.Net.Auth0/Auth0IdentityProvider.cs
@@ -1,9 +1,7 @@
-﻿using System.Web;
-using OidcProxy.Net.IdentityProviders;
+﻿using Duende.IdentityModel.Client;
 using OidcProxy.Net.Logging;
 using OidcProxy.Net.OpenIdConnect;
 using Microsoft.Extensions.Caching.Memory;
-using IdentityModel.Client;
 
 namespace OidcProxy.Net.Auth0;
 

--- a/src/OidcProxy.Net.EntraId/OidcProxy.Net.EntraId.csproj
+++ b/src/OidcProxy.Net.EntraId/OidcProxy.Net.EntraId.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OidcProxy.Net.OpenIdConnect/JsonWebKeySet.cs
+++ b/src/OidcProxy.Net.OpenIdConnect/JsonWebKeySet.cs
@@ -4,7 +4,7 @@ namespace OidcProxy.Net.OpenIdConnect;
 
 internal class JsonWebKeySet : List<KeySet>
 {
-    internal static JsonWebKeySet Create(IdentityModel.Client.JsonWebKeySetResponse jwksResponse)
+    internal static JsonWebKeySet Create(Duende.IdentityModel.Client.JsonWebKeySetResponse jwksResponse)
     {
         var keySets = jwksResponse.KeySet?.Keys
             .Select(x =>

--- a/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
+++ b/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
@@ -33,7 +33,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
+        <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OidcProxy.Net.OpenIdConnect/OpenIdConnectIdentityProvider.cs
+++ b/src/OidcProxy.Net.OpenIdConnect/OpenIdConnectIdentityProvider.cs
@@ -1,9 +1,9 @@
 using System.Net;
 using System.Web;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using Duende.IdentityModel.OidcClient;
 using OidcProxy.Net.IdentityProviders;
-using IdentityModel;
-using IdentityModel.Client;
-using IdentityModel.OidcClient;
 using Microsoft.Extensions.Caching.Memory;
 using OidcProxy.Net.Cryptography;
 using OidcProxy.Net.Logging;


### PR DESCRIPTION
This commit updates the codebase to replace the IdentityModel library with the Duende IdentityModel library. Changes include updating namespaces, modifying package references in project files, and adjusting method signatures to ensure compatibility with the new library. The `IdentityModel.OidcClient` package has been replaced with `Duende.IdentityModel.OidcClient`, along with necessary updates to relevant classes and methods.